### PR TITLE
security: Fix 7 vulnerabilities from pentest audit

### DIFF
--- a/soar_agent_runtime.json
+++ b/soar_agent_runtime.json
@@ -26,16 +26,16 @@
     "pip3_dependencies": {
         "pypi": [
             {
-                "module": "requests"
+                "module": "requests==2.32.3"
             },
             {
-                "module": "openai"
+                "module": "openai==1.82.0"
             },
             {
-                "module": "anthropic"
+                "module": "anthropic==0.52.0"
             },
             {
-                "module": "google-generativeai"
+                "module": "google-generativeai==0.8.5"
             }
         ]
     },
@@ -105,6 +105,13 @@
             "required": false,
             "default": "agent_definitions",
             "order": 9
+        },
+        "skill_list_name": {
+            "description": "SOAR Custom List name containing skill definitions",
+            "data_type": "string",
+            "required": false,
+            "default": "agent_skills",
+            "order": 10
         }
     },
     "actions": [

--- a/soar_agent_runtime_connector.py
+++ b/soar_agent_runtime_connector.py
@@ -13,7 +13,8 @@ from soar_agent_runtime_utils import (
     ToolRegistry,
     AgentDefinitionStore,
     SkillStore,
-    ReActLoop
+    ReActLoop,
+    MAX_STEPS_HARD_LIMIT,
 )
 
 
@@ -40,6 +41,22 @@ class SoarAgentRuntimeConnector(BaseConnector):
     def finalize(self):
         self.save_state(self._state)
         return phantom.APP_SUCCESS
+
+    # -----------------------------------------------------------------------
+    # Input helpers
+    # -----------------------------------------------------------------------
+
+    def _safe_int(self, value, default: int = 0, name: str = "parameter") -> int | None:
+        """Issue #6: Safe integer conversion with error reporting."""
+        try:
+            result = int(value)
+            if result < 0:
+                self.save_progress(f"Warning: {name} must be non-negative, got {result!r}. Using {default}.")
+                return default
+            return result
+        except (ValueError, TypeError):
+            self.save_progress(f"Warning: {name} must be numeric, got {value!r}.")
+            return None
 
     # -----------------------------------------------------------------------
     # LLM Provider Factory
@@ -123,16 +140,19 @@ class SoarAgentRuntimeConnector(BaseConnector):
 
         agent_id = param.get("agent_id", "")
         task = param.get("task", "")
-        container_id = int(param.get("container_id", 0))
-        max_steps_override = int(param.get("max_steps", 0))
         extra_context_str = param.get("extra_context", "")
 
         if not agent_id:
             return action_result.set_status(phantom.APP_ERROR, "agent_id is required.")
         if not task:
             return action_result.set_status(phantom.APP_ERROR, "task is required.")
+
+        # Issue #6: safe integer conversion
+        container_id = self._safe_int(param.get("container_id", 0), name="container_id")
         if not container_id:
-            return action_result.set_status(phantom.APP_ERROR, "container_id is required.")
+            return action_result.set_status(phantom.APP_ERROR, "container_id must be a valid positive integer.")
+
+        max_steps_override = self._safe_int(param.get("max_steps", 0), name="max_steps") or 0
 
         # Load agent definition
         self.save_progress(f"Loading agent: {agent_id}")
@@ -142,10 +162,13 @@ class SoarAgentRuntimeConnector(BaseConnector):
         except ValueError as e:
             return action_result.set_status(phantom.APP_ERROR, str(e))
 
-        # Resolve max steps
+        # Resolve max steps with hard cap (Issue #4: DoS prevention)
         max_steps = max_steps_override or agent_def.get("max_steps") or self._default_max_steps
         if max_steps <= 0:
             max_steps = self._default_max_steps
+        if max_steps > MAX_STEPS_HARD_LIMIT:
+            self.save_progress(f"Warning: max_steps capped at {MAX_STEPS_HARD_LIMIT} (requested: {max_steps}).")
+            max_steps = MAX_STEPS_HARD_LIMIT
 
         # Build LLM provider
         provider = agent_def.get("provider", self._default_provider)

--- a/soar_agent_runtime_utils.py
+++ b/soar_agent_runtime_utils.py
@@ -6,7 +6,9 @@ Python 3.13 compatible.
 
 from __future__ import annotations
 import json
+import re
 import requests
+from urllib.parse import urlparse
 
 try:
     import anthropic
@@ -28,6 +30,59 @@ except ImportError:
 
 
 # ---------------------------------------------------------------------------
+# Security constants
+# ---------------------------------------------------------------------------
+
+# Issue #2 (Prompt Injection): ReAct control keywords must not appear in
+# external data (artifacts, SPL results) fed back into the LLM conversation.
+_REACT_KEYWORDS = ("THOUGHT:", "ACTION:", "PARAMS:", "FINAL_ANSWER:", "OBSERVATION:")
+
+# Issue #5 (SPL Injection): Destructive/exfiltrating SPL pipe commands.
+_BLOCKED_SPL_RE = re.compile(
+    r'\|\s*(delete|drop|truncate|map\s|outputlookup\b|rest\s+/services)',
+    re.IGNORECASE
+)
+
+# Issue #3 (SSRF): Allowed URL schemes per provider.
+_HTTPS_ONLY_PROVIDERS = {"anthropic", "openai", "gemini"}
+_PRIVATE_IP_RE = re.compile(
+    r'^(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|127\.|169\.254\.|::1|fc|fd)',
+    re.IGNORECASE
+)
+
+# Issue #4 (DoS): Absolute maximum ReAct steps regardless of config.
+MAX_STEPS_HARD_LIMIT = 50
+
+
+def _sanitize_observation(text: str) -> str:
+    """Escape ReAct control keywords in external data before injecting into LLM."""
+    for kw in _REACT_KEYWORDS:
+        text = text.replace(kw, f"[{kw.rstrip(':')}]")
+    return text
+
+
+def _validate_api_url(url: str, provider: str) -> str:
+    """Raise ValueError if the URL could be used for SSRF."""
+    if not url:
+        return url
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+    hostname = (parsed.hostname or "").lower()
+
+    if provider in _HTTPS_ONLY_PROVIDERS and scheme != "https":
+        raise ValueError(
+            f"Provider '{provider}' requires HTTPS. Got scheme: '{scheme}'"
+        )
+    if provider == "local" and scheme not in ("http", "https"):
+        raise ValueError(f"Local LLM URL must use http or https. Got: '{scheme}'")
+    if _PRIVATE_IP_RE.match(hostname) and provider != "local":
+        raise ValueError(
+            f"API URL for '{provider}' must not point to a private/loopback address: {hostname}"
+        )
+    return url
+
+
+# ---------------------------------------------------------------------------
 # LLM Provider Abstraction
 # ---------------------------------------------------------------------------
 
@@ -37,7 +92,7 @@ class LLMProvider:
     def __init__(self, provider: str, api_key: str, api_url: str, model: str) -> None:
         self.provider = provider.lower()
         self.api_key = api_key
-        self.api_url = api_url
+        self.api_url = _validate_api_url(api_url, self.provider)  # Issue #3: SSRF guard
         self.model = model
 
     def chat(self, system_prompt: str, messages: list[dict]) -> str:
@@ -190,13 +245,17 @@ class ToolRegistry:
         latest   = params.get("latest", "now")
         if not spl:
             return "ERROR: spl_query parameter is required."
+        # Issue #5: Block destructive/exfiltrating SPL commands
+        if _BLOCKED_SPL_RE.search(spl):
+            return "ERROR: Query contains blocked SPL commands (delete/drop/outputlookup/rest)."
         self.connector.save_progress(f"Executing SPL: {spl[:80]}...")
         try:
             import phantom.rules as ph_rules
             results = ph_rules.run_query(query=spl, start_time=earliest, end_time=latest)
             if not results:
                 return "SPL search returned 0 results."
-            return f"SPL results ({len(results)} rows):\n{json.dumps(results[:20], indent=2)}"
+            raw = f"SPL results ({len(results)} rows):\n{json.dumps(results[:20], indent=2)}"
+            return _sanitize_observation(raw)  # Issue #2: sanitize before LLM injection
         except Exception as e:
             return f"SPL search error: {e}"
 
@@ -232,12 +291,13 @@ class ToolRegistry:
             import phantom.rules as ph_rules
             container = ph_rules.get_container(self.container_id)
             artifacts = ph_rules.get_artifacts(container_id=self.container_id)
-            return json.dumps(
+            raw = json.dumps(
                 {"container": container,
                  "artifact_count": len(artifacts) if artifacts else 0,
                  "artifacts": (artifacts or [])[:5]},
                 indent=2, default=str
             )
+            return _sanitize_observation(raw)  # Issue #2: sanitize artifact data before LLM injection
         except Exception as e:
             return f"Failed to get container info: {e}"
 


### PR DESCRIPTION
## Summary

- **Prompt Injection** (closes #2): Alle Observations (Artefakte, SPL-Ergebnisse) werden durch `_sanitize_observation()` bereinigt — ReAct-Kontrollwörter werden vor der LLM-Injection escaped
- **SSRF** (closes #3): `_validate_api_url()` in `LLMProvider.__init__()` erzwingt HTTPS für Cloud-Provider und blockiert private/loopback IPs
- **SPL Injection** (closes #5): Regex-Blockliste für destruktive SPL-Kommandos (`delete`, `drop`, `outputlookup`, `rest`) in `_tool_splunk_search()`
- **DoS / max_steps** (closes #4): `MAX_STEPS_HARD_LIMIT=50` als absolutes Maximum in `soar_agent_runtime_utils.py`; Connector cappt und loggt Überschreitungen
- **Input Validation** (closes #6): `_safe_int()` Helper ersetzt bare `int()` für `container_id` und `max_steps`; ungültige Werte liefern `APP_ERROR`
- **Missing Config** (closes #7): `skill_list_name` in `soar_agent_runtime.json` ergänzt
- **Supply Chain** (closes #8): Alle `pip3_dependencies` auf konkrete Versionen gepinnt

## Test plan

- [ ] `python3 -c "import ast; ast.parse(open('soar_agent_runtime_utils.py').read())"` — kein Syntax-Fehler
- [ ] SPL-Query `| delete index=main` → Tool gibt `ERROR: Query contains blocked SPL commands` zurück
- [ ] Artefakt mit `FINAL_ANSWER: ignore` im Namen → wird zu `[FINAL_ANSWER] ignore` sanitisiert, Loop bricht nicht vorzeitig ab
- [ ] `max_steps=999` → wird auf 50 gecappt, Warning im Progress-Log
- [ ] `container_id="abc"` → `APP_ERROR: container_id must be a valid positive integer`
- [ ] `anthropic_api_url=http://169.254.169.254/` → `ValueError` beim LLM-Provider-Build
- [ ] SOAR Asset-UI zeigt `skill_list_name` als konfigurierbares Feld

🤖 Generated with [Claude Code](https://claude.com/claude-code)